### PR TITLE
Set up relup generation

### DIFF
--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -25,6 +25,6 @@ jobs:
       run: rebar3 check
     - name: Release can be built
       working-directory: erlang
-      run: rebar3 as prod tar
+      run: rebar3 do release, tar
 
     ## TODO: check about version bumps

--- a/.github/workflows/publish-tarball.yml
+++ b/.github/workflows/publish-tarball.yml
@@ -10,6 +10,7 @@ on:
 env:
   BUCKET_NAME: ferd-dandelion
   RELNAME: dandelion
+  REGION: us-east-1
 
 jobs:
 
@@ -22,13 +23,43 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Fetch manifest version
+        run: |
+          S3_URL="https://${BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com"
+          RET=0
+          NEW_VSN=${GITHUB_REF##*/v}
+          OLD_VSN=$(curl "${S3_URL}/${RELEASE}-latest" -s --fail) || RET=$?
+          echo "VSN=$NEW_VSN" >> $GITHUB_ENV
+          if [ $RET -eq 0 ]; then
+              echo "OLD_VSN=$OLD_VSN" >> $GITHUB_ENV
+              IS_UPGRADE=$(echo "$NEW_VSN $OLD_VSN" | awk -vFS='[. ]' '($1==$4 && $2>$5) || ($1==$4 && $2>=$5 && $3>$6) {print 1; exit} {print 0}')
+              if [ "$IS_UPGRADE" -eq 1 ]; then
+                  echo "RELUP=1" >> $GITHUB_ENV
+              else
+                  echo "RELUP=0" >> $GITHUB_ENV
+              fi
+          else
+            echo "RELUP=0" >> $GITHUB_ENV
+          fi
+      - run: |
+          echo "${{ env.OLD_VSN }} -> ${{ env.VSN }} : ${{ env.RELUP }}"
       - name: Build a tarball
         working-directory: erlang
         run: |
-          rebar3 as prod tar
-          BUILD=$(ls _build/prod/rel/${{ env.RELNAME }}/${{ env.RELNAME }}-*.tar.gz)
+          if [ ${{ env.RELUP }} -eq 1 ]; then
+            git checkout v${{ env.OLD_VSN }}
+            rebar3 release
+            git checkout v${{ env.VSN }}
+            rebar3 release
+            rebar3 appup generate
+            rebar3 relup -n ${{ env.RELNAME }} -v ${{ env.VSN }} -u ${{ env.OLD_VSN }}
+          else
+            rebar3 release
+          fi
+          rebar3 tar
+          BUILD=$(ls _build/default/rel/${{ env.RELNAME }}/${{ env.RELNAME }}-*.tar.gz)
           mkdir ../_artifacts
-          cp $BUILD ../_artifacts/${{ env.RELNAME }}-${GITHUB_REF##*/}.tar.gz
+          cp $BUILD ../_artifacts/${{ env.RELNAME }}-${{ env.VSN }}.tar.gz
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -60,6 +91,6 @@ jobs:
       - name:  Put release in bucket
         run: |
           aws s3 cp _artifacts/${{ env.RELNAME }}-*.tar.gz s3://${{ env.BUCKET_NAME }}/
-          echo ${GITHUB_REF##*/} > _artifacts/${{ env.RELNAME }}-latest
+          echo ${GITHUB_REF##*/v} > _artifacts/${{ env.RELNAME }}-latest
           aws s3 cp _artifacts/${{ env.RELNAME }}-latest s3://${{ env.BUCKET_NAME }}/
 

--- a/.github/workflows/publish-tarball.yml
+++ b/.github/workflows/publish-tarball.yml
@@ -23,13 +23,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Fetch manifest version
         run: |
-          S3_URL="https://${BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com"
+          S3_URL="https://${BUCKET_NAME}.s3.${{ env.REGION }}.amazonaws.com"
           RET=0
           NEW_VSN=${GITHUB_REF##*/v}
-          OLD_VSN=$(curl "${S3_URL}/${RELEASE}-latest" -s --fail) || RET=$?
           echo "VSN=$NEW_VSN" >> $GITHUB_ENV
+          OLD_VSN=$(curl "${S3_URL}/${{ env.RELNAME }}-latest" -s --fail) || RET=$?
+          echo "${S3_URL}/${{ env.RELNAME }}-latest" $OLD_VSN "-" $RET
           if [ $RET -eq 0 ]; then
               echo "OLD_VSN=$OLD_VSN" >> $GITHUB_ENV
               IS_UPGRADE=$(echo "$NEW_VSN $OLD_VSN" | awk -vFS='[. ]' '($1==$4 && $2>$5) || ($1==$4 && $2>=$5 && $3>$6) {print 1; exit} {print 0}')

--- a/erlang/apps/dandelion/src/dandelion.app.src
+++ b/erlang/apps/dandelion/src/dandelion.app.src
@@ -1,6 +1,6 @@
 {application, dandelion,
  [{description, "A plant in the wrong place"},
-  {vsn, "0.1.0"},
+  {vsn, "0.1.1"},
   {registered, []},
   {mod, {dandelion_app, []}},
   {applications,

--- a/erlang/apps/dandelion/src/dandelion.app.src
+++ b/erlang/apps/dandelion/src/dandelion.app.src
@@ -1,6 +1,6 @@
 {application, dandelion,
  [{description, "A plant in the wrong place"},
-  {vsn, "0.1.1"},
+  {vsn, "0.1.2"},
   {registered, []},
   {mod, {dandelion_app, []}},
   {applications,

--- a/erlang/apps/dandelion/src/dandelion_conn.erl
+++ b/erlang/apps/dandelion/src/dandelion_conn.erl
@@ -37,7 +37,7 @@ handle_cast(_Cast, State) ->
     {noreply, State}.
 
 handle_info(display, State=#{sock := Sock}) ->
-    Str = "\n"
+    Str = "    \n"
           "   @\n"
           " \ |\n"
           "__\!/__\n\n",

--- a/erlang/apps/dandelion/src/dandelion_conn.erl
+++ b/erlang/apps/dandelion/src/dandelion_conn.erl
@@ -7,6 +7,7 @@
 -behaviour(gen_server).
 
 -define(CONTINUE_WAIT, 500).
+-define(DISPLAY_DELAY, timer:seconds(2)).
 
 -export([start_link/1]).
 -export([init/1, handle_continue/2, handle_call/3, handle_cast/2, handle_info/2]).
@@ -22,6 +23,7 @@ handle_continue(wait_control, State=#{sock := Sock}) ->
     %% The wait shouldn't be long
     receive
         {ready, Sock} ->
+            display_event(),
             inet:setopts(Sock, [{active, once}]),
             {noreply, State}
     after ?CONTINUE_WAIT ->
@@ -34,11 +36,23 @@ handle_call(_Call, _From, State) ->
 handle_cast(_Cast, State) ->
     {noreply, State}.
 
+handle_info(display, State=#{sock := Sock}) ->
+    Str = "\n"
+          "   @\n"
+          " \ |\n"
+          "__\!/__\n\n",
+    gen_tcp:send(Sock, Str),
+    display_event(),
+    {noreply, State};
 handle_info({tcp, Sock, _Msg}, State=#{sock := Sock}) ->
     inet:setopts(Sock, [{active, once}]),
-    gen_tcp:send(Sock, ".\n"),
+    {ok, Vsn} = application:get_key(dandelion, vsn),
+    gen_tcp:send(Sock, "vsn: " ++ Vsn ++ "\n"),
     {noreply, State};
 handle_info({tcp_error, _Sock, Reason}, State) ->
     {stop, {shutdown, {sock, Reason}}, State};
 handle_info({tcp_closed, _Sock}, State) ->
     {stop, {shutdown, {sock, closed}}, State}.
+
+display_event() ->
+    erlang:send_after(?DISPLAY_DELAY, self(), display).

--- a/erlang/rebar.config
+++ b/erlang/rebar.config
@@ -26,7 +26,7 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-{relx, [{release, {dandelion, "0.1.1"},
+{relx, [{release, {dandelion, "0.1.2"},
          [dandelion,
           sasl]},
 

--- a/erlang/rebar.config
+++ b/erlang/rebar.config
@@ -4,6 +4,17 @@
     ]}
 ]}.
 
+{plugins, [
+    {rebar3_appup_plugin, {git, "https://github.com/lrascao/rebar3_appup_plugin",
+                            {branch, "develop"}}}
+]}.
+{provider_hooks, [
+    {pre, [{tar, {appup, tar}}]},
+        {post, [{compile, {appup, compile}},
+            {clean, {appup, clean}}]}
+]}.
+
+
 {cover_enabled, true}.
 {cover_opts, [verbose, {min_coverage, 20}]}.
 
@@ -15,40 +26,33 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-{relx, [{release, {dandelion, "0.1.0"},
+{relx, [{release, {dandelion, "0.1.1"},
          [dandelion,
           sasl]},
-
-        {mode, dev},
 
         %% automatically picked up if the files
         %% exist but can be set manually, which
         %% is required if the names aren't exactly
         %% sys.config and vm.args
         {sys_config_src, "./config/sys.config.src"},
-        {vm_args, "./config/vm.args"}
+        {vm_args, "./config/vm.args"},
 
-        %% the .src form of the configuration files do
-        %% not require setting RELX_REPLACE_OS_VARS
-        %% {sys_config_src, "./config/sys.config.src"},
-        %% {vm_args_src, "./config/vm.args.src"}
+        %% We could use {mode, prod} here, but since I'm developing this
+        %% with a mix of github CI on x86 and of a microk8s cluster
+        %% running on a m1 macbook, the final image is run on a linux on
+        %% aarch64. As such, minimal mode omits the ERTS, and using an
+        %% Erlang base image lets us do portable builds so long as we don't
+        %% start relying on NIFs.
+        %%
+        %% This conveniently allows/demands that pods get restarted when
+        %% we upgrade the VM as well.
+        {include_src, false},
+        {include_erts, false},
+        {debug_info, keep},
+        {dev_mode, false}
 ]}.
 
 {profiles, [
-    {prod, [
-        {relx, [
-            %% We could use {mode, prod} here, but since I'm developing this
-            %% with a mix of github CI on x86 and of a microk8s cluster
-            %% running on a m1 macbook, the final image is run on a linux on
-            %% aarch64. As such, minimal mode omits the ERTS, and using an
-            %% Erlang base image lets us do portable builds so long as we don't
-            %% start relying on NIFs.
-            %%
-            %% This conveniently allows/demands that pods get restarted when
-            %% we upgrade the VM as well.
-            {mode, minimal}
-        ]}
-    ]},
     {test, [
         {erl_opts, [nowarn_export_all]}
     ]}

--- a/k8s/dandelion.yaml
+++ b/k8s/dandelion.yaml
@@ -74,8 +74,6 @@ spec:
         ports:
           - containerPort: 8080
             hostPort: 8080
-        # TODO: configure epmd on 4369
-        # TODO: expose 8080
       - name: dandelion-sidecar
         image: erlang:25.0.2
         env:
@@ -101,7 +99,6 @@ spec:
           mountPath: /scripts
         command:
           - /scripts/update-loop.sh
-        # TODO: configure epmd on 4369
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -149,11 +146,13 @@ data:
         CURRENT=$(${RELDIR}/bin/${RELEASE} versions | awk '$3=="permanent" && !vsn { vsn=$2 } $3=="current" { vsn=$2 } END { print vsn }')
         TAG=$(curl "${S3_URL}/${RELEASE}-latest" -s)
         if [[ "${CURRENT}" != "${TAG}" ]]; then
-            # TODO: add check for downgrade or un-upgradable release
-            wget -nv "${S3_URL}/${RELEASE}-${TAG}.tar.gz" -O "${RELDIR}/releases/${RELEASE}-${TAG}.tar.gz"
-            ${RELDIR}/bin/${RELEASE} unpack ${TAG}
-            ${RELDIR}/bin/${RELEASE} install ${TAG}
-            ${RELDIR}/bin/${RELEASE} upgrade ${TAG}
+            IS_UPGRADE=$(echo "$NEW_VSN $OLD_VSN" | awk -vFS='[. ]' '($1==$4 && $2>$5) || ($1==$4 && $2>=$5 && $3>$6) {print 1; exit} {print 0}')
+            if [[ $IS_UPGRADE -eq 1 ]]; then
+              wget -nv "${S3_URL}/${RELEASE}-${TAG}.tar.gz" -O "${RELDIR}/releases/${RELEASE}-${TAG}.tar.gz"
+              ${RELDIR}/bin/${RELEASE} unpack ${TAG}
+              ${RELDIR}/bin/${RELEASE} install ${TAG}
+              ${RELDIR}/bin/${RELEASE} upgrade ${TAG}
+            fi
         fi
     done
 ---


### PR DESCRIPTION
- Include the relup plugin from source (more up to date)
- Drop the prod profile for releases and always run as prod (to work
  better with the plugin)
- Call release before tar to generate some metadata files
- Fixing version munging for tags in gh actions
- Optionally generate relup files based on versions and existing
  manifest data