### PR TITLE
Work around CI filesystem cache issues?

### DIFF
--- a/.github/workflows/publish-tarball.yml
+++ b/.github/workflows/publish-tarball.yml
@@ -50,10 +50,11 @@ jobs:
         working-directory: erlang
         run: |
           if [ ${{ env.RELUP }} -eq 1 ]; then
+            ORIG=$(/usr/bin/git log -1 --format='%H')
             git checkout v${{ env.OLD_VSN }}
-            rebar3 release
-            git checkout v${{ env.VSN }}
-            rebar3 release
+            rebar3 do clean -a, release
+            git checkout $ORIG
+            rebar3 do clean -a, release
             rebar3 appup generate
             rebar3 relup -n ${{ env.RELNAME }} -v ${{ env.VSN }} -u ${{ env.OLD_VSN }}
           else

--- a/erlang/apps/dandelion/src/dandelion.app.src
+++ b/erlang/apps/dandelion/src/dandelion.app.src
@@ -1,6 +1,6 @@
 {application, dandelion,
  [{description, "A plant in the wrong place"},
-  {vsn, "0.1.4"},
+  {vsn, "0.1.5"},
   {registered, []},
   {mod, {dandelion_app, []}},
   {applications,

--- a/erlang/apps/dandelion/src/dandelion_conn.erl
+++ b/erlang/apps/dandelion/src/dandelion_conn.erl
@@ -37,7 +37,7 @@ handle_cast(_Cast, State) ->
     {noreply, State}.
 
 handle_info(display, State=#{sock := Sock}) ->
-    Str = "      *\n"
+    Str = " \n"
           "   @\n"
           " \\ |\n"
           "__\\!/__\n\n",

--- a/erlang/rebar.config
+++ b/erlang/rebar.config
@@ -26,7 +26,7 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-{relx, [{release, {dandelion, "0.1.4"},
+{relx, [{release, {dandelion, "0.1.5"},
          [dandelion,
           sasl]},
 

--- a/scripts/check_versions
+++ b/scripts/check_versions
@@ -9,9 +9,9 @@ main([Branch]) ->
     "v"++_LastVsn = LastTag = string:trim(os:cmd("git tag -l --sort=committerdate 'v*.*.*' | tail -n 1")),
     io:format("switching to ~ts and back to ~ts~n", [LastTag, Branch]),
     io:format("~p: ~ts~n", [?LINE, os:cmd("git checkout "++LastTag)]),
-    io:format("~p: ~ts~n", [?LINE, os:cmd("rebar3 do release, tar")]),
+    io:format("~p: ~ts~n", [?LINE, os:cmd("rebar3 do clean -a, release, tar")]),
     io:format("~p: ~ts~n", [?LINE, os:cmd("git checkout "++Branch)]),
-    io:format("~p: ~ts~n", [?LINE, os:cmd("rebar3 release")]),
+    io:format("~p: ~ts~n", [?LINE, os:cmd("rebar3 do clean -a, release")]),
     RelFiles = filelib:wildcard("_build/default/rel/*/releases/**/*.rel"),
     case length(RelFiles) of
         2 ->


### PR DESCRIPTION
Never replicated this locally, but in github actions it appears that
artifacts from previous build somehow mess with the scripts and a clean
step guarantees better behaviour.